### PR TITLE
fix: restrict pymatgen version and update installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ source gnrs_env/bin/activate
 
 ### Install Build Dependencies
 
-Install build dependencies and `mpi4py` with the correct MPI compiler **before** installing the package:
+Install build dependencies, PyTorch, and `mpi4py` with the correct MPI compiler **before** installing the package:
 
 ```bash
-pip install "setuptools>=61.0" wheel "swig>=4.1,<4.3" pybind11 Cython "numpy>=2.0,<2.3"
-MPICC=$(which mpicc) pip install mpi4py --no-cache-dir
+pip install "setuptools>=61.0" wheel "swig>=4.1,<4.3" Cython "numpy>=2.0,<2.3"
+pip install torch==2.8.0 --index-url https://download.pytorch.org/whl/cu129
+MPICC=$(which mpicc) pip install mpi4py --no-binary mpi4py
 ```
 
 > [!NOTE]

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -43,12 +43,12 @@ conda activate gnrs_env
 
 ## Install Build Dependencies
 
-Install the build dependencies **before** installing the package, so that
-`mpi4py` is compiled against the correct MPI compiler on your system:
+Install build dependencies, PyTorch, and `mpi4py` with the correct MPI compiler **before** installing the package:
 
 ```bash
-pip install "setuptools>=61.0" wheel "swig>=4.1,<4.3" pybind11 Cython "numpy>=2.0,<2.3"
-MPICC=$(which mpicc) pip install mpi4py --no-cache-dir
+pip install "setuptools>=61.0" wheel "swig>=4.1,<4.3" Cython "numpy>=2.0,<2.3"
+pip install torch==2.8.0 --index-url https://download.pytorch.org/whl/cu129
+MPICC=$(which mpicc) pip install mpi4py --no-binary mpi4py
 ```
 
 :::{note}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "mpi4py",
     "ase",
     "spglib",
-    "pymatgen",
+    "pymatgen<=2025.10.7",
     "matplotlib",
     "pyyaml",
     "tqdm",


### PR DESCRIPTION
- Pin pymatgen to <= 2025.10.7, due to its [major reorganization](https://github.com/materialsproject/pymatgen/pull/4595)

> `pymatgen.analysis.structure_matcher` has been moved to `pymatgen.core.structure_matcher`

- Update installation docs