### PR TITLE
fix(symm_rigid_press): skip structures when spglib returns None

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Yi5817/Genarris/releases"><img src="https://img.shields.io/badge/version-3.1.0-green" alt="Version 3.1.0"></a>
+  <a href="https://github.com/Yi5817/Genarris/releases"><img src="https://img.shields.io/github/v/release/Yi5817/Genarris?filter=gnrs-*&display_name=release&label=version&color=green" alt="Version"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+"></a>
   <a href="https://github.com/Yi5817/Genarris/actions/workflows/lint.yml"><img src="https://github.com/Yi5817/Genarris/actions/workflows/lint.yml/badge.svg" alt="Code Style"></a>
   <a href="https://yi5817.github.io/Genarris/"><img src="https://github.com/Yi5817/Genarris/actions/workflows/docs.yml/badge.svg" alt="Documentation"></a>
@@ -29,7 +29,7 @@ Clone the repository:
 Create and activate the virtual enviornment using your favorite venv tool:
 
 ```bash
-virtualenv -p python3.11 gnrs_env
+python3 -m venv gnrs_env
 source gnrs_env/bin/activate
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Genarris supports various energy calculators through the [ASE Calculator](https:
 
 > :warning: To access gated UMA models, you need to get a HuggingFace account and request access to the [UMA model repository](https://huggingface.co/facebook/UMA).
 
+### Updating
+
+`git pull` alone does **not** sync submodules. To update an existing clone, run:
+
+```bash
+git pull
+git submodule sync --recursive
+git submodule update --init --recursive
+```
+
+`sync` is only required when `.gitmodules` changes (URL, branch, or path), but running it every time is harmless.
+
 ## Quick Start
 
 Genarris uses a [configuration file](https://docs.python.org/3/library/configparser.html) to control crystal structure generation and selection.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 ```
 
 <p align="center" class="badges">
-<a href="https://github.com/Yi5817/Genarris/releases"><img src="https://img.shields.io/badge/version-3.1.0-green" alt="Version 3.1.0"></a>
+<a href="https://github.com/Yi5817/Genarris/releases"><img src="https://img.shields.io/github/v/release/Yi5817/Genarris?filter=gnrs-*&display_name=release&label=version&color=green" alt="Version"></a>
 <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+"></a>
 <a href="https://github.com/Yi5817/Genarris/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-BSD--3--Clause-blue" alt="License"></a>
 <a href="https://doi.org/10.1021/acs.jctc.5c01080"><img src="https://img.shields.io/badge/DOI-10.1021%2Facs.jctc.5c01080-blue" alt="DOI"></a>

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -89,6 +89,18 @@ rigid_press = Extension(
 
 :::
 
+## Updating
+
+`git pull` alone does **not** sync submodules. To update an existing clone, run:
+
+```bash
+git pull
+git submodule sync --recursive
+git submodule update --init --recursive
+```
+
+`sync` is only required when `.gitmodules` changes (URL, branch, or path), but running it every time is harmless.
+
 ## Optional Energy Calculators
 
 Genarris supports various energy calculators through the

--- a/gnrs/optimize/rpress_symm_impl.py
+++ b/gnrs/optimize/rpress_symm_impl.py
@@ -101,6 +101,11 @@ def find_symm(xtal: Atoms, natoms: int) -> tuple[np.ndarray, np.ndarray, int]:
         (xtal.get_cell(), xtal.get_scaled_positions(), xtal.get_atomic_numbers()),
         symprec=1e-3,
     )
+    if symm is None:
+        # spglib failed to determine the symmetry of this structure
+        raise ValueError(
+            "spglib get_symmetry_dataset returned None for this crystal "
+        )
     spg = symm.number
     rot, trans = symm.rotations, symm.translations
 

--- a/gnrs/parallel/io.py
+++ b/gnrs/parallel/io.py
@@ -42,9 +42,12 @@ def read_geometry_out(file_path: str) -> dict:
 
     str_data = gp.comm.scatter(str_data, root=0)
     struct_list = [
-        str2atoms(str_geo.split("\n"))
-        for str_geo in str_data
-        if str_geo is not None
+        geo for geo in (
+            str2atoms(str_geo.split("\n"))
+            for str_geo in str_data
+            if str_geo is not None
+        )
+        if geo is not None
     ]
     # random IDs
     struct_dict = {f"{random.getrandbits(60):x}": s for s in struct_list}
@@ -52,7 +55,7 @@ def read_geometry_out(file_path: str) -> dict:
     return struct_dict
 
 
-def str2atoms(geometry_str: list) -> Atoms:
+def str2atoms(geometry_str: list) -> Atoms | None:
     """
     Constructs Atoms object from aims geometry format.
     
@@ -63,12 +66,12 @@ def str2atoms(geometry_str: list) -> Atoms:
         ASE Atoms object representing the crystal structure
     """
     species, cell, pos, spg = [], [], [], None
-    
+
     for line in geometry_str:
         sline = line.split()
         if not sline:
             continue
-            
+
         if "lattice_vector" in line:
             cell.append([float(x) for x in sline[1:4]])
         elif sline[0] == "atom":
@@ -76,6 +79,8 @@ def str2atoms(geometry_str: list) -> Atoms:
             species.append(sline[4])
         elif "SPGLIB_detected_spacegroup" in line:
             spg = int(sline[-1])
+            if spg == 0:
+                return None
 
     xtal = Atoms(symbols="".join(species), positions=pos, cell=cell, pbc=True)
     if spg is not None:


### PR DESCRIPTION
In find_symm, get_symmetry_dataset can return None for generated crystals with near-degenerate or overlapping atomic positions. The previous code then did spg = symm.number, raising AttributeError that was not caught by run_batch (which only catches ValueError/RuntimeError), aborting the entire MPI job.

Raise a ValueError instead so run_batch in core/optimizer.py logs the failure, drops the offending structure, and continues with the rest of the pool.