### PR TITLE
Update and rename dftbp.py to dftb.py

### DIFF
--- a/gnrs/energy/dftb.py
+++ b/gnrs/energy/dftb.py
@@ -16,7 +16,7 @@ from ase.calculators.dftb import Dftb
 from gnrs.core.energy import EnergyCalculatorABC
 
 
-class DFTBPEnergy(EnergyCalculatorABC):
+class DFTBEnergy(EnergyCalculatorABC):
     """
     Computes energy using DFTB+ code.
     https://wiki.fysik.dtu.dk/ase/ase/calculators/dftb.html


### PR DESCRIPTION
Fixed discrepancy between workflow keyword ('dftb') and gnrs/energy file/module ('dftbp') for DFTB+ interface. 

Tested for tight binding energy calculations and optimization (bfgs_*) and DFTB+ is correctly initiated in both instances. 

If desired, it can be reworked to go in the other direction ('dftb'->'dftbp').